### PR TITLE
Replace exa with eza

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,7 +10,7 @@ brew "grep"
 brew "trash"
 brew "git"
 brew "coreutils"
-brew "exa"
+brew "eza"
 brew "asdf"
 
 tap "homebrew/cask"

--- a/zsh/.aliasrc
+++ b/zsh/.aliasrc
@@ -26,7 +26,7 @@ alias bx="bundle exec"
 alias bup="bundle update"
 
 alias ls="gls --color --group-directories-first -l"
-alias ll="exa --long"
+alias ll="eza --long"
 
 alias cr=crystal
 


### PR DESCRIPTION
exa was discontinued in favor of eza